### PR TITLE
Recursive promise resolution #4

### DIFF
--- a/lib/express_promise.js
+++ b/lib/express_promise.js
@@ -6,14 +6,27 @@ var isMongooseQuery = function(v) {
   return v !== null && typeof v === 'object' && typeof v.exec === 'function';
 };
 
-var resolveAsync = function(object, callback) {
+var MAX_PROMISE = 10;
+
+var resolveAsync = function(object, callback, count) {
   if (!object || typeof object !== 'object') {
     return callback(null, object);
   }
 
+  /* Maintain count on how many promises to attempt to resolve */
+  count = count || MAX_PROMISE;
+  if (count === 0) {
+    return callback(new Error('Max promises ('+MAX_PROMISE+') reached'));
+  }
+
+
   if (isPromise(object)) {
     return object.then(function(result) {
-      callback(null, result);
+      if (isPromise(result)) {
+        resolveAsync(result, callback, count-1);
+      } else {
+        callback(null, result);
+      }
     }, function(err) {
       callback(err);
     });

--- a/test/recursive.js
+++ b/test/recursive.js
@@ -1,0 +1,29 @@
+require('./spec_helper');
+var expressPromise = require('..');
+
+describe('recursive', function() {
+  it('should resolve a promise that resolves with a promise', function(done) {
+    var res = {
+      json: function(body) {
+        body.a.should.equal('hi');
+        done();
+      }
+    };
+
+    expressPromise({methods: ['json']})(null, res);
+    function async(callback) {
+      callback(null, 'hi');
+    }
+    function doubleAsync(callback) {
+      callback(null, async.promise());
+    }
+
+    res.json({
+      a: doubleAsync.promise()
+    });
+
+  });
+
+});
+
+


### PR DESCRIPTION
Fixes #4. Implements recursive promise resolution and adds a test case.

Should also catch any looping resolutions by throwing error at a MAX_PROMISE iteration.
