### PR TITLE
Added posibility to skip toJSON and then filter objects by user own function

### DIFF
--- a/lib/express_promise.js
+++ b/lib/express_promise.js
@@ -44,7 +44,7 @@ var resolveAsync = function(object, callback, count, options) {
     return callback(null, object);
   }
 
-  if (typeof object.toJSON === 'function') {
+  if (typeof object.toJSON === 'function' && !options.disableJSONify && !options.disableJSONify(object)) {
     object = object.toJSON();
     if (!object || typeof object !== 'object') {
       return callback(null, object);
@@ -88,6 +88,8 @@ var resolveAsync = function(object, callback, count, options) {
       item.exec(function(err, result) {
         handleDone(err, result);
       });
+    } else if(options.objectFilter && options.objectFilter(object[item.key])) {
+      handleDone(null, object[item.key]);
     } else {
       resolveAsync(object[item.key], handleDone, count - 1, options);
     }
@@ -188,16 +190,14 @@ var expressPromise = function(options) {
               return next(err);
             }
             if (typeof status !== 'undefined') {
-              res.status(status);
-              originalResSend(result);
+              originalResSend(status, result);
             } else {
               originalResSend(result);
             }
           }, options.maxPromise, options);
         } else {
           if (status) {
-            res.status(status);
-            originalResSend(body);
+            originalResSend(status, body);
           } else {
             originalResSend(body);
           }


### PR DESCRIPTION
When working with Sequelize i created model instance method item.url() and want to use it inside Jade code, also mixed with providing Promise to render method, so i could't use skipTraverse.
I had added two optional functions
```javascript
app.use(require('express-promise')({
    disableJSONify: function (object) {
        return true; //You can add more logic here if you want to select which page would passed without toJSON call
    },
    objectFilter: function (object) {
        if (object && object.model) //Example for Sequelize, will skip object if it was ORM model
            return true;
        return false;
    }
}));
```